### PR TITLE
Detect all Trackers, not just those assigned to roles

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ find_package(Protobuf CONFIG REQUIRED)
 set(protos_OUTPUT_DIR ${CMAKE_CURRENT_BINARY_DIR}/protos)
 
 # Project
-add_executable("${PROJECT_NAME}" "src/main.cpp" "src/pathtools_excerpt.cpp" "src/pathtools_excerpt.h" "src/matrix_utils.cpp" "src/matrix_utils.h" "src/bridge.cpp" "src/bridge.hpp" "src/setup.cpp" "src/setup.hpp" "ProtobufMessages.proto")
+add_executable("${PROJECT_NAME}" "src/main.cpp" "src/pathtools_excerpt.cpp" "src/pathtools_excerpt.h" "src/matrix_utils.cpp" "src/matrix_utils.h" "src/bridge.cpp" "src/bridge.hpp" "src/setup.cpp" "src/setup.hpp" "ProtobufMessages.proto" "${CMAKE_CURRENT_BINARY_DIR}/version.h")
 target_link_libraries("${PROJECT_NAME}" PRIVATE "${OPENVR_LIB}" fmt::fmt protobuf::libprotobuf)
 protobuf_generate(TARGET "${PROJECT_NAME}" LANGUAGE cpp PROTOC_OUT_DIR ${protos_OUTPUT_DIR})
 target_include_directories("${PROJECT_NAME}" PUBLIC ${protos_OUTPUT_DIR} PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
@@ -23,8 +23,8 @@ target_compile_features("${PROJECT_NAME}" PRIVATE cxx_std_17)
 source_group(TREE "${CMAKE_CURRENT_SOURCE_DIR}/src" PREFIX "Header Files" FILES ${HEADERS})
 source_group(TREE "${CMAKE_CURRENT_SOURCE_DIR}/src" PREFIX "Source Files" FILES ${SOURCES})
 
-add_custom_command(TARGET SlimeVR-Feeder-App
-    PRE_BUILD
+add_custom_command(
+    OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/version.h"
     COMMAND ${CMAKE_COMMAND}
         -Dlocal_dir="${CMAKE_CURRENT_SOURCE_DIR}"
         -Doutput_dir="${CMAKE_CURRENT_BINARY_DIR}"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@ source_group(TREE "${CMAKE_CURRENT_SOURCE_DIR}/src" PREFIX "Header Files" FILES 
 source_group(TREE "${CMAKE_CURRENT_SOURCE_DIR}/src" PREFIX "Source Files" FILES ${SOURCES})
 
 add_custom_command(
-    OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/version.h"
+    OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/version.h" always_run
     COMMAND ${CMAKE_COMMAND}
         -Dlocal_dir="${CMAKE_CURRENT_SOURCE_DIR}"
         -Doutput_dir="${CMAKE_CURRENT_BINARY_DIR}"


### PR DESCRIPTION
Kinda rewrote-ish a good portion of the feeder app in the process. whoops?

Current methodology is as follows:
 - Try to detect all trackers by index, with role NONE.
 - Try to detect all trackers through action system, with their respective roles.
 - If pose NONE, put the tracker into a waiting state. On timeout, we notify the server of the tracker with role NONE.
 - otherwise we notify the server immediately.

This supports updating the role of a tracker so long as the role doesn't change to NONE. I'm not changing that right now. should probably list that as a known issue in the README I guess.