### PR TITLE
Don't send HMD to SlimeVR Server

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -289,6 +289,10 @@ private:
 			return; // don't send information on slimes
 		}
 
+		if (index == 19) {
+			return; // don't send HMD
+		}
+
 		if (info->status == status_val && !send_anyway) {
 			return; // already up to date;
 		}
@@ -324,6 +328,10 @@ private:
 
 		if (info->is_slimevr) {
 			return; // don't bother with slimes
+		}
+
+		if (index == 19) {
+			return; // don't send HMD
 		}
 
 		if (pose.bPoseIsValid || pose.eTrackingResult == ETrackingResult::TrackingResult_Fallback_RotationOnly) {
@@ -409,6 +417,10 @@ private:
 
 		if (info->is_slimevr) {
 			return; // don't send information on slimes
+		}
+
+		if (index == 19) {
+			return; // don't send HMD
 		}
 
 		bool should_send = false;


### PR DESCRIPTION
The SlimeVR OpenVR Driver and Feeder App both currently send the HMD to the SlimeVR Server, causing there to be a duplicate of the HMD. By not sending the HMD from the Feeder App, this resolves this issue.

I don't think there should be any problem with doing this, but this is mostly just in response to a cosmetic issue from there being two HMDs in the SlimeVR Server.