### PR TITLE
Hide window on Windows by default

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -21,6 +21,10 @@
 #include "version.h"
 #include <ProtobufMessages.pb.h>
 
+#if defined(WIN32)
+#include <Windows.h>
+#endif
+
 using namespace vr;
 
 // TODO: Temp Path
@@ -757,6 +761,8 @@ int main(int argc, char* argv[]) {
 	args::Flag install(setup_group, "install", "Installs the manifest and enables autostart. Used by the installer.", {"install"});
 	args::Flag uninstall(setup_group, "uninstall", "Removes the manifest file.", {"uninstall"});
 
+	args::Flag show_console(parser, "console", "Show the command line output which is hidden by default.", {"console"});
+
 	std::string configFileName = Path_MakeAbsolute(config_path, Path_StripFilename(Path_GetExecutablePath()));
 	std::ifstream configFile(configFileName);
 
@@ -833,6 +839,21 @@ int main(int argc, char* argv[]) {
 	if (!maybe_trackers.has_value()) {
 		return EXIT_FAILURE;
 	}
+
+#if defined(WIN32)
+	// Hide command line output after any potential error
+	if (!show_console) {
+		// Thanks https://stackoverflow.com/a/78943791
+		HWND hwnd = GetConsoleWindow();
+		HWND owner = GetWindow(hwnd, GW_OWNER);
+		if (owner == NULL) {
+		    ShowWindow(hwnd, SW_HIDE); // Windows 10
+		}
+		else {
+		    ShowWindow(owner, SW_HIDE);// Windows 11
+		}
+	}
+#endif
 
 	Trackers trackers = maybe_trackers.value();
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -761,7 +761,7 @@ int main(int argc, char* argv[]) {
 	args::Flag install(setup_group, "install", "Installs the manifest and enables autostart. Used by the installer.", {"install"});
 	args::Flag uninstall(setup_group, "uninstall", "Removes the manifest file.", {"uninstall"});
 
-	args::Flag show_console(parser, "console", "Show the command line output which is hidden by default.", {"console"});
+	args::Flag show_console(parser, "console", "Show the command line output which is hidden by default on Windows.", {"console"});
 
 	std::string configFileName = Path_MakeAbsolute(config_path, Path_StripFilename(Path_GetExecutablePath()));
 	std::ifstream configFile(configFileName);
@@ -844,13 +844,13 @@ int main(int argc, char* argv[]) {
 	// Hide command line output after any potential error
 	if (!show_console) {
 		// Thanks https://stackoverflow.com/a/78943791
-		HWND hwnd = GetConsoleWindow();
-		HWND owner = GetWindow(hwnd, GW_OWNER);
-		if (owner == NULL) {
-		    ShowWindow(hwnd, SW_HIDE); // Windows 10
+		HWND console = GetConsoleWindow();
+		HWND console_owner = GetWindow(console, GW_OWNER);
+		if (console_owner == NULL) {
+		    ShowWindow(console, SW_HIDE);
 		}
 		else {
-		    ShowWindow(owner, SW_HIDE);// Windows 11
+		    ShowWindow(console_owner, SW_HIDE); // Windows Terminal
 		}
 	}
 #endif


### PR DESCRIPTION
This will hide the terminal window on Windows after any potential errors or setup procedure are done.  
A lot of people don't like having a terminal window pop up every time they launch VR and even disable the feeder app for this reason alone.  
The feeder app is now discreet and won't bother users.  
--console can be used to still see the console.  

![image](https://github.com/user-attachments/assets/3a501d1d-bbb1-4a14-8d01-dc80e3b8a409)
